### PR TITLE
feat(dynamic-postscreen-reset): add a function to reset all screens

### DIFF
--- a/css/add-post.css
+++ b/css/add-post.css
@@ -65,6 +65,8 @@
   flex: 2 1 0;
 }
 
+/**/
+
 /* ===================== HISTORY HEADER ===================== */
 .history-header {
   max-height: 0;
@@ -121,6 +123,7 @@
 /* ===================== PREVIEW CONTAINER ===================== */
 #addPost .preview-container {
   display: flex;
+
   overflow: hidden;
   gap: 20px;
   align-items: flex-start;
@@ -131,6 +134,7 @@
 
 #addPost .preview-container .image-preview-container {
 	display: flex;
+	
 	overflow: hidden;
 	gap: 20px;
 	align-items: center;
@@ -142,8 +146,7 @@
 }
 #addPost .preview-container .image-preview-container span.button {
 	width: 100px;
-  min-width: unset;
-	height: 150px;
+	height: 100px;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
@@ -151,14 +154,6 @@
 	margin: 0;
 	line-height: inherit;
 	border: 0;
-	background-color: transparent;
-}
-#addPost .preview-container .image-preview-container span.button i {
-	line-height: 0;
-}
-#addPost .preview-container .image-preview-container span.button:hover{
-
-	background-color: var(--bg-filter);
 }
 #addPost .preview-container .image-preview-container .preview-track-wrapper {
   display: flex;
@@ -192,9 +187,6 @@
   align-content: center;
   align-items: center;
   height: 100%;
-  border-radius: 2rem;
-  overflow: hidden;
-  transition: all 0.3s;
 }
 
 #addPost .preview-item p {
@@ -206,29 +198,11 @@
 #addPost .preview-item img {
   height: 100%;
   width: auto;
+
+  border-radius: 2rem;
 }
 #addPost .preview-item img.create-img {
   cursor: move;
-}
-#preview-image .preview-item .editImage {
-	display: flex;
-	align-items: center;
-	gap: 5px;
-	position: absolute;
-	height: auto !important;
-	transform: translateY(50px);
-	opacity: 0;
-	transition: all 0.3s;
-  z-index: 1;
-}
-
-#preview-image .preview-item:hover img.create-img
-{
-  opacity: 0.5;
-}
-#preview-image .preview-item:hover .editImage  {
-  transform: translateY(0);
-	opacity: 1;
 }
 
 #addPost .preview-item progress {
@@ -243,7 +217,7 @@
   cursor: pointer;
 }
 
-#addPost #preview-video .preview-container {
+#addPost #preview-video.preview-container {
   flex-wrap: nowrap;
   height: auto;
   align-items: center;
@@ -253,13 +227,13 @@
   min-height: 30vh !important;
   max-height: 30vh;
 }
-#addPost #preview-video .preview-container > div img.create-img,
-#addPost #preview-video .preview-container > div video {
+#addPost #preview-video.preview-container > div img.create-img,
+#addPost #preview-video.preview-container > div video {
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
-#addPost #preview-video .preview-container > div video {
+#addPost #preview-video.preview-container > div video {
   position: absolute;
   object-fit: contain !important;
 }
@@ -351,12 +325,6 @@
 .voice-media {
   background-color: #333;
   border-radius: 1rem;
-  position: relative;
-  padding: 40px;
-}
-
-.voice-media .recording-bar-img {
-  width: 100%;
 }
 
 /* ===================== IMAGE PREVIEW ===================== */
@@ -391,7 +359,6 @@
   font-weight: 600;
   font-size: 1rem;
 }
-
 /* ===================== Tags ===================== */
 .tag-wrapper {
   background-color: var(--bg-filter);
@@ -435,11 +402,9 @@
   opacity: 0;
   visibility: hidden;
 }
-
 .tag-section.visible,
 .tag-section.is-visible {
-  border-top: 1px solid var(--white-secondary, rgba(255, 255, 255, 0.50));
-
+  border-top: 1px solid var(--white-secondary, rgba(255, 255, 255, 0.5));
   margin: 0 40px;
   padding: 40px 0;
   display: block;
@@ -450,14 +415,12 @@
   overflow: visible;
   transform: translateY(0);
 }
-
 .tag-section .section-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   margin-bottom: 40px;
 }
-
 .tag-section.selected-tags {
   border: 0;
 }
@@ -466,9 +429,7 @@
   margin: 0;
   border: 0;
   padding: 0;
-
   background-color: var(--red-accent, #ff3b3b);
-
   font-weight: 400;
   cursor: pointer;
   color: #fff;
@@ -485,7 +446,6 @@
   visibility: hidden;
   transition: all 0.3s ease;
 }
-
 .tag-list .tag:hover .remove-tag {
   opacity: 1;
   visibility: visible;
@@ -493,7 +453,6 @@
 }
 
 .tag-list .tag .remove-tag:hover {
-
   color: var(--red-accent, #ff3b3b);
   background-color: var(--white, #fff);
 }
@@ -506,12 +465,10 @@
   display: block;
   margin: 0;
 }
-
 #createPostError.response_msg {
   text-align: right;
   padding-right: 60px;
 }
-
 .resettable-form .form-row .col-right .textarea-wrapper {
   position: relative;
   max-height: 250px;
@@ -552,35 +509,22 @@
 
 /* === Mic Button (before recording) === */
 .micButton {
-    transition: all 0.3s ease;
-    position: absolute;
-    top: 50%;
-    right: 50%;
-    transform: translate(50%, -50%);
+  background: transparent;
+  /* border: 2px solid white;
+  border-radius: 50%; */
+  font-size: 2rem;
+  /* width: 3.5rem;
+  height: 3.5rem; */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: white;
+  cursor: pointer;
+  transition: background 0.3s ease;
 }
 
-.micButton span.icon-mic {
-    background: var(--blue);
-    display: flex;
-    width: 200px;
-    height: 200px;
-    padding: 20px;
-    justify-content: center;
-    align-items: center;
-    gap: 10px;
-    aspect-ratio: 1/1;
-    border-radius: 100%;
-}
-
-.voice-media.active .micButton {
-    right: 0;
-    transform: translate(0%, -50%);
-}
-
-.voice-media.active .micButton span.icon-mic {
-    background: var(--bg-filter);
-    border: 3px solid;
-    cursor: pointer;
+.micButton.recording {
+  background: rgba(255, 255, 255, 0.1);
 }
 
 /* === Recording Box (appears when recording starts) === */
@@ -615,7 +559,6 @@
   0% {
     opacity: 0.3;
   }
-
   50% {
     opacity: 1;
   }
@@ -641,7 +584,6 @@
   background: repeating-linear-gradient(to right, white 0, white 2px, transparent 2px, transparent 6px);
   opacity: 0.3;
   animation: pulse 1s linear infinite;
-
   border-radius: 1rem;
 }
 
@@ -667,9 +609,6 @@
 /* === Time Text (live timer while playing) === */
 .record-time {
   color: white;
-  position: absolute;
-  bottom: 1rem;
-  left: 1rem;
 }
 
 /* default: hide all */
@@ -693,30 +632,6 @@
   display: block;
 }
 
-#preview-audio .record-again {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background-color: var(--blue);
-    width: 100%;
-    padding: 0 65px;
-    line-height: 100px;
-    border-radius: 100px;
-    font-size: 24px;
-}
-
-#preview-audio .record-again span.icon-mic {
-    font-size: 50px;
-    line-height: 0;
-}
-#preview-audio .record-again span.icon-mic svg {
-    width: 38px;
-    height: auto;
-}
-/*********************/
-.form-actions button {
-  min-width: 300px;
-=======
 /*********************/
 .form-actions button {
   min-width: 150px;
@@ -742,18 +657,15 @@
   .form-actions button {
     min-width: 500px;
   }
-
   .tag-wrapper {
     border-radius: 70px;
   }
-
   .tag-list .tag {
     padding: 0 50px;
     line-height: 100px;
   }
 
   .tag-list .tag .remove-tag {
-
     width: 40px;
 
     line-height: 40px;

--- a/css/view-post.css
+++ b/css/view-post.css
@@ -16,7 +16,6 @@
 }
 
 .previewPost .inner-container {
-  top: 47% !important;
   height: 80vh !important;
 }
 
@@ -110,6 +109,7 @@
   overflow-wrap: break-word;
   white-space: normal;
   word-break: break-word;
+  overflow-y: auto;
   
 }
 .viewpost .post_content .hashtags {
@@ -845,13 +845,13 @@
 .foot-end {
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: space-around;
   align-items: center;
-  width: 40%;
-  position: absolute;
-  bottom: 0;
-  margin-left: 120px;
-  margin-bottom: 100px;
+  width: 50vw;
+  position: fixed;
+  bottom: 50px;
+  left: 30%;
+  transform: translateX(-50%);
 }
 
 .switch-buttons {
@@ -859,9 +859,7 @@
   border-radius: 2.5rem;
   overflow: hidden;
   background-color: var(--dark-inactive, #323232);;
-  width: 100%;
-  max-width: 400px;
-}
+  padding: 0.3rem;}
 
 .switch-btn {
   flex: 1;

--- a/js/add_post.js
+++ b/js/add_post.js
@@ -220,7 +220,7 @@ document.addEventListener("DOMContentLoaded", () => {
     h2.textContent = objekt.title || "";
 
     const time = document.createElement("span");
-    time.className = "timeagao";
+    time.className = "timeagao txt-color-gray";
     time.textContent = "1 sec ago";
 
     titleEl.appendChild(h2);
@@ -314,9 +314,6 @@ document.addEventListener("DOMContentLoaded", () => {
             // Optionally: toggle active class for UI
             document.querySelectorAll('.form-tab-js').forEach(item => item.classList.remove('active'));
             this.closest('.form-tab-js').classList.add('active');
-
-            // Call your custom content-switching logic if needed (e.g. loadImageForm(), loadVideoForm())
-            // You may already have something like that in your JS handling post type switch.
         });
     });
 
@@ -995,6 +992,36 @@ document.addEventListener("DOMContentLoaded", () => {
         const post_type = e.target.getAttribute("data-post-type");
         postform.setAttribute("data-post-type", post_type);
       }
+      // Update the <h1 id="h1"> with the selected post type
+      const post_type = e.target.getAttribute("data-post-type");
+      const header = document.getElementById("h1");
+      if (header && post_type) {
+        const labels = {
+          text: "Text Post",
+          image: "Image Post",
+          video: "Video Post",
+          audio: "Music Post"
+        };
+        header.textContent = labels[post_type] ;
+      }
+
+
+      // Clear text inputs when switching tabs
+      const titleInput = document.getElementById("titleNotes");
+      const descInput = document.getElementById("descriptionNotes");
+      const tagInput = document.getElementById("tag-input");
+      const tagSelected = document.getElementById("tagsSelected");
+      const charCount = document.querySelector(".char-counter .char_count");
+      const titleError = document.getElementById("titleError");
+
+      if (titleInput) titleInput.value = "";
+      if (descInput) descInput.value = "";
+      if (tagInput) tagInput.value = "";
+      if (tagSelected) tagSelected.innerHTML = "";
+      if (charCount) charCount.textContent = "0";
+      if (titleError) titleError.textContent = "";
+
+
       // Check if it's the audio form (music) and init
       if (id === "preview-audio") initAudioEvents(); // attach mic click handler
 

--- a/newpost.php
+++ b/newpost.php
@@ -52,7 +52,7 @@ checkAuth("unauthorized");
     <div id="addPost" class="site_layout">
         <header class="site-header header-profile">
             <img class="logo" src="svg/plus2.svg" alt="Peer Network">
-            <h1 id="h1">New Post</h1>
+            <h1 id="h1">Text Post</h1>
         </header>
 
         <aside class="left-sidebar left-sidebar-createpost">

--- a/template-parts/content-parts/preview.php
+++ b/template-parts/content-parts/preview.php
@@ -257,9 +257,9 @@
         </div>
         <div class="foot-end">
             <button id="cancel_Btn" class="btn-transparent cancel_Btn">Cancel</button>
-            <div class="switch-buttons">
-                <button class="switch-btn active">Full post</button>
-                <button class="switch-btn">Collapsed</button>
+            <div class="aspect-ratio-toggle">
+                <label for="ar-1">Full post</label>
+                <label for="ar-2">Collapsed</label>
             </div>
         </div>
     </div>


### PR DESCRIPTION
this mr introduces:
Description
Implement functionality to dynamically update the header and visible content area when switching between post types (text, image, video, audio).
Each time a new post type screen is selected, the title, description, and tags fields should be emptied to ensure clean data entry and prevent cross-type residue.

Scope (What’s Included)
Update the post creation flow to dynamically change the header text (e.g., “New Text Post”, “New Audio Post”) depending on the selected type.

Display only the relevant input fields and UI components per post type (e.g., show file upload for image, audio recorder for audio).

Ensure that switching between post types resets all input fields:

Clear the title, description, and tags inputs.

Ensure previously uploaded media (image, video, audio) is cleared on screen switch.

Update navigation or tabs (if any) to reflect the active screen visually.

Maintain consistency with the current design system and ensure responsive behavior.

