### PR TITLE
feat(previewAudio-cover): add feature to preview audio cover when added

### DIFF
--- a/css/view-post.css
+++ b/css/view-post.css
@@ -18,6 +18,9 @@
 .blur {
 	opacity: 0.5;
 }
+.comment-txt {
+	margin: auto;
+}
 .collapsed-slider {
 	position: relative;
 	width: 100%;
@@ -118,6 +121,10 @@
   opacity: 0;
   transition: opacity 0.4s ease;
 }
+.disabled {
+	cursor: not-allowed;
+	pointer-events: none;
+}
 
 .collapsed-slide.active {
   opacity: 1;
@@ -190,7 +197,9 @@
   justify-content: space-between;
   align-items: flex-start;
   gap:50px;
-  margin-top: -90px;
+}
+.previewPost .inner-container {
+	margin-top: -90px;
 }
 .viewpost .inner-container .btClose {
 	z-index: 2;
@@ -1042,7 +1051,7 @@ button:not(:disabled):hover.switch-btn {
 	margin-top: 200px;
   }
 
-  .viewpost .inner-container {
+  .previewPost .inner-container {
   	margin-top: -50px;
    }
 }

--- a/js/register/register.js
+++ b/js/register/register.js
@@ -12,7 +12,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const referralInputs = document.querySelectorAll("#referral_code");
   const validationMsg = document.getElementById("refValidationMessage");
-  const staticUUID = "8e2b5672-84bd-4a5c-a5d0-f4bfc212ec2a";
+  const staticUUID = "85d5f836-b1f5-4c4e-9381-1b058e13df93";
   let autoFillCode = null;
 
   const formSteps = document.querySelectorAll(".form-step");

--- a/profile.php
+++ b/profile.php
@@ -61,10 +61,10 @@ checkAuth("unauthorized");
   
     <div class="profile_header" id="profil-container">
       <div class="profile_picture">
-        <div class="cropContainer"><span class="online_status"></span><img id="profilbild" class="profile-picture" src="svg/noname.svg" alt="Profile Picture" /></div>
+        <div class="cropContainer"><span class="online_status"></span><img id="profilbild" class="profilbild profile-picture" src="svg/noname.svg" alt="Profile Picture" /></div>
       </div>
       <div class="profile_info">
-        <h2 class="profile_title"><span  id="username">&nbsp;</span><span id="slug" class="profile_no">&nbsp;</span></h2>
+        <h2 class="profile_title"><span class="username"  id="username">&nbsp;</span><span class="slug" id="slug" class="profile_no">&nbsp;</span></h2>
         <div class="profile_description" id="biography"> </div>
         <div class="profile_stats"> <span class="post_count"><em id="userPosts">&nbsp;</em> Posts</span> <span id="followers_count" class="followers_count"><em id="followers">&nbsp;</em> <span class="new_count" id="recent_followers"></span> Followers</span> <span id="following_count" class="following_count"><em id="following">&nbsp;</em> Following</span> <span id="peer_count" class="peer_count"><em id="Peers">0</em> Peers</span> </div>
         <div id="modal_Overlay" class="modalOverlay none"></div>

--- a/template-parts/content-parts/preview.php
+++ b/template-parts/content-parts/preview.php
@@ -64,9 +64,10 @@
                 <div class="comments-container">
                     <div class="comments-header">
                         <h3 class="cmt_head xxl_font_size">Comments</h3>
-                        <span class="comment_total md_font_size"><i class="fi fi-sr-comment-dots"></i> <span class="comment_count">42</span></span>
+                        <span class="comment_total md_font_size"><i class="fi fi-sr-comment-dots"></i> <span class="comment_count">0</span></span>
                         <span class="cmt-scroll none">Comment Scroll</span>
                     </div>
+                    <span class="comment-txt blur"> No comments yet. Be the first to comment! </span>
                     <!-- <div  class="comment_list">
                         <div id="comments" class="inner"> 
                             <!-- <div class="comment_item"> 
@@ -245,7 +246,7 @@
                     </div> -->
                     
                 </div>
-                <div id="post_comment" class="post_comment">
+                <div id="post_comment" class="disabled post_comment">
                         <textarea placeholder="Share your thoughts ..." autocomplete="off" autocorrect="off" spellcheck="false"></textarea>
                         <button><i class="fi fi-ts-arrow-small-right"></i></button>
                 </div>


### PR DESCRIPTION
Description
This feature adds support for previewing the audio cover image in the post creation interface before submitting an audio post. When users upload an audio file along with an optional cover image, the interface will now display the selected cover image as a preview within the post layout, providing users with a clearer view of how their post will appear.

Scope (What’s Included)
Frontend support to preview the cover image for audio posts.

Dynamic display of the uploaded cover (if present) alongside the audio player.

Conditional rendering logic to ensure the preview only appears when contenttype === "audio" and a cover is provided.

Clean handling when switching between post types (image/video/audio/text) to avoid display overlaps.

