### PR TITLE
sec: cutover-window hardening — fix download.php SSRF, drop phpinfo, harden auth cookies + admin gate

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -59,12 +59,29 @@ function graphqlRequest(string $domain, string $protocol, string $query, array $
  * Store auth and helper cookies with optional long-term expiry.
  */
 function setAuthCookies(string $accessToken, string $refreshToken, bool $rememberMe, ?string $email = null, ?string $password = null): void {
-    $expiry = $rememberMe ? time() + (60) : 0; // approx. 10 years 3650 * 24 * 60 * 
+    // M12 (Plan v2): three changes from the previous Phase-1 cookie code.
+    //
+    //   1. `httponly = true` — JS no longer reads `authToken`. Closes the
+    //      XSS-takeover path; previously a single XSS exfiltrated the
+    //      session token.
+    //   2. Remember-me expiry math fixed. Previous `time() + (60)` was
+    //      60 SECONDS, not 10 years (the comment admitted the operand
+    //      tail was missing). Now `time() + (60*60*24*365)` = 1 year.
+    //   3. The plaintext `userPassword` cookie is no longer written
+    //      under any circumstance. Remember-me used to round-trip the
+    //      password by replaying the Login mutation; that's now the
+    //      `attemptTokenRefresh` path only — refresh tokens are the
+    //      durable credential.
+    //
+    // The `$password` parameter is intentionally ignored; the signature
+    // is preserved so existing call-sites compile, but every caller
+    // should drop it on a follow-up cleanup.
+    $expiry = $rememberMe ? time() + (60 * 60 * 24 * 365) : 0;
     $options = [
         'expires' => $expiry,
         'path' => '/',
         'secure' => true,
-        'httponly' => false,
+        'httponly' => true,
         'samesite' => 'Strict',
     ];
 
@@ -75,22 +92,24 @@ function setAuthCookies(string $accessToken, string $refreshToken, bool $remembe
     if ($email !== null) {
         setcookie('userEmail', $email, $options);
     }
-
-    if ($password !== null) {
-        setcookie('userPassword', $password, $options);
-    }
+    // Note: `userPassword` cookie write is intentionally removed.
+    // See the comment block at the top of this function.
+    unset($password); // Silence unused-param tooling.
 }
 
 /**
  * Remove all auth related cookies.
  */
 function clearAuthCookies(): void {
+    // Includes `userPassword` in the kill-list to scrub stale plaintext
+    // cookies left over from before M12 — anyone who was logged in with
+    // remember-me prior to this commit will have one in their browser.
     $names = ['authToken', 'refreshToken', 'rememberMe', 'userEmail', 'userPassword'];
     $options = [
         'expires' => time() - 3600,
         'path' => '/',
         'secure' => true,
-        'httponly' => false,
+        'httponly' => true,
         'samesite' => 'Strict',
     ];
     foreach ($names as $name) {
@@ -319,8 +338,15 @@ function enforceAllowedUser(array $allowedUserIds, string $domain, string $proto
  * Deny access unless the current user role string is ADMIN.
  */
 function enforceAdminRole(string $domain, string $protocol = 'https'): void {
-    $role = fetchUserRoleString($domain, $protocol); 
-    if ($role !== 'MODERATOR') {
+    // M12 (Plan v2): widened to also admit ADMIN / SUPER_ADMIN /
+    // SUPER_MODERATOR. The previous `!== 'MODERATOR'` check let only
+    // moderators through despite the function being named `enforceAdminRole`,
+    // which means real admins were locked out of the moderation panel.
+    // Peergamma's `is_admin()` and `is_moderator()` both grant access to
+    // moderation endpoints; mirroring that union here.
+    $role = strtoupper((string)fetchUserRoleString($domain, $protocol));
+    $allowed = ['MODERATOR', 'SUPER_MODERATOR', 'ADMIN', 'SUPER_ADMIN'];
+    if (!in_array($role, $allowed, true)) {
         http_response_code(403);
         exit('Access denied');
     }

--- a/download.php
+++ b/download.php
@@ -1,18 +1,136 @@
 <?php
+/**
+ * Hardened download proxy. Replaces the previous SSRF-vulnerable
+ * `readfile($_GET['file'])` with:
+ *
+ *   - HTTPS-only (any other scheme rejected)
+ *   - Host allow-list (env DOWNLOAD_ALLOWED_HOSTS, csv; defaults
+ *     to media.peerapp.eu, cdn.peerapp.eu, media.peernetwork.eu,
+ *     media.getpeer.eu)
+ *   - Size cap (env DOWNLOAD_MAX_BYTES, default 256 MiB) — checked
+ *     against Content-Length pre-stream and against bytes-read
+ *     mid-stream
+ *   - Connect + total timeout (env DOWNLOAD_TIMEOUT_SECS, default 300)
+ *   - Userinfo URLs rejected
+ *   - Filename sanitisation: strips `/`, `\`, `..`, control chars
+ *   - Hard-codes Content-Type: application/octet-stream and
+ *     X-Content-Type-Options: nosniff
+ *
+ * Operational note: nginx / Cloudflare must rate-limit `/download`
+ * before this script — there is no application-level limiter here.
+ *
+ * Mirrors the Leptos SSR replacement at
+ * `peer_web_frontend/src/server/download.rs` on the spike branch.
+ * When that ships in production, this file can be retired.
+ */
+
 if (!isset($_GET['file'])) {
-    die("No file specified.");
+    http_response_code(400);
+    exit('Missing file parameter.');
 }
 
 $fileUrl = $_GET['file'];
-$filename = basename($fileUrl);
 
-// remote file stream karo
-header("Content-Type: application/octet-stream");
-header("Content-Disposition: attachment; filename=\"$filename\"");
-header("Content-Transfer-Encoding: binary");
-header("Cache-Control: must-revalidate");
-header("Pragma: public");
+// ---- 1. Parse + scheme + userinfo guard ----
+$parts = parse_url($fileUrl);
+if ($parts === false || empty($parts['scheme']) || empty($parts['host'])) {
+    http_response_code(400);
+    exit('Malformed URL.');
+}
+if (strtolower($parts['scheme']) !== 'https') {
+    http_response_code(400);
+    exit('Only HTTPS URLs are permitted.');
+}
+if (!empty($parts['user']) || !empty($parts['pass'])) {
+    http_response_code(400);
+    exit('URL userinfo is not permitted.');
+}
 
-// directly stream file to user
-readfile($fileUrl);
+// ---- 2. Host allow-list ----
+$defaultHosts = 'media.peerapp.eu,cdn.peerapp.eu,media.peernetwork.eu,media.getpeer.eu';
+$allowedRaw = getenv('DOWNLOAD_ALLOWED_HOSTS');
+$allowedHosts = array_filter(array_map(
+    fn($h) => strtolower(trim($h)),
+    explode(',', $allowedRaw !== false ? $allowedRaw : $defaultHosts)
+));
+$host = strtolower($parts['host']);
+if (!in_array($host, $allowedHosts, true)) {
+    http_response_code(403);
+    exit('Host not in allow-list.');
+}
+
+// ---- 3. Size + timeout caps ----
+$maxBytesRaw = getenv('DOWNLOAD_MAX_BYTES');
+$maxBytes = (int)($maxBytesRaw !== false ? $maxBytesRaw : (256 * 1024 * 1024));
+$timeoutRaw = getenv('DOWNLOAD_TIMEOUT_SECS');
+$timeoutSecs = (int)($timeoutRaw !== false ? $timeoutRaw : 300);
+
+// ---- 4. Filename sanitisation ----
+$rawFilename = basename($parts['path'] ?? '') ?: 'download.bin';
+$filename = preg_replace('/[\x00-\x1f\\\\\\/]/', '', $rawFilename);
+$filename = ltrim($filename, '.');
+if ($filename === '' || $filename === '.' || $filename === '..') {
+    $filename = 'download.bin';
+}
+if (strlen($filename) > 200) {
+    $filename = substr($filename, 0, 200);
+}
+
+// ---- 5. HEAD-then-GET to enforce Content-Length pre-stream. ----
+$headCtx = stream_context_create([
+    'http' => [
+        'method' => 'HEAD',
+        'timeout' => $timeoutSecs,
+        'follow_location' => 0, // No redirect chasing — would bypass allow-list.
+        'ignore_errors' => true,
+    ],
+]);
+@get_headers($fileUrl, false, $headCtx); // populates $http_response_header
+if (isset($http_response_header)) {
+    foreach ($http_response_header as $h) {
+        if (preg_match('/^content-length:\s*(\d+)/i', $h, $m)) {
+            if ((int)$m[1] > $maxBytes) {
+                http_response_code(413);
+                exit('Content too large.');
+            }
+        }
+    }
+}
+
+// ---- 6. Stream with byte counter. ----
+$ctx = stream_context_create([
+    'http' => [
+        'method' => 'GET',
+        'timeout' => $timeoutSecs,
+        'follow_location' => 0,
+        'ignore_errors' => true,
+    ],
+]);
+$in = @fopen($fileUrl, 'rb', false, $ctx);
+if ($in === false) {
+    http_response_code(502);
+    exit('Upstream unavailable.');
+}
+
+header('Content-Type: application/octet-stream');
+header('X-Content-Type-Options: nosniff');
+header('Cache-Control: private, no-store');
+header('Content-Disposition: attachment; filename="' . addcslashes($filename, '"\\') . '"');
+
+$readSoFar = 0;
+while (!feof($in)) {
+    $chunk = fread($in, 8192);
+    if ($chunk === false || $chunk === '') {
+        break;
+    }
+    $readSoFar += strlen($chunk);
+    if ($readSoFar > $maxBytes) {
+        // Mid-stream cap exceeded — abort cleanly.
+        fclose($in);
+        // Headers already sent; just stop writing.
+        exit;
+    }
+    echo $chunk;
+}
+fclose($in);
 exit;

--- a/phpinfo.php
+++ b/phpinfo.php
@@ -1,1 +1,0 @@
-<?php phpinfo(); ?>


### PR DESCRIPTION
## Summary

Three CVE-class issues in the soon-to-retire PHP frontend, fixed surgically so the cutover window (until Leptos ships) is safe.

1. **`download.php` SSRF** — was `readfile(\$_GET['file'])` with no validation. Now a hardened proxy: HTTPS-only, host allow-list, size + time caps, no redirect chasing, userinfo rejected, filename sanitised. Mirrors the Leptos SSR replacement at `peer_web_frontend/src/server/download.rs` on the spike.

2. **`phpinfo.php` deleted** — was `<?php phpinfo(); ?>`, reachable, not on the `.htaccess` `FilesMatch` block. Information disclosure vector. Gone.

3. **`auth.php`** — three fixes:
   - `setAuthCookies`: `httponly = true`, plaintext `userPassword` cookie write removed, remember-me expiry math fixed (`time() + 60` ⇒ 1 year).
   - `clearAuthCookies`: matches `httponly = true`, keeps `userPassword` in the kill-list to scrub legacy cookies.
   - `enforceAdminRole`: widened from `!== 'MODERATOR'` to admit `MODERATOR`, `SUPER_MODERATOR`, `ADMIN`, `SUPER_ADMIN` (PHP backend's moderation resolvers grant the same union; the previous narrow check locked actual admins out of the moderation panel despite the function name).

## Operator notes

- **`/download` rate limiting must be at nginx / Cloudflare.** No app-level limiter in this script.
- The `\$password` parameter on `setAuthCookies` is preserved in the signature but ignored — drop it on a follow-up cleanup once callsites stop passing it.
- Returning users with a legacy plaintext `userPassword` cookie will get it cleared on their next logout (kill-list still includes it).

## Out of scope

- JWT signature verification in `decodeJwtPayload` (lower severity — the backend verifies on every call; deferred).
- `GraphGL` typo rename (cosmetic).
- CSRF middleware (relies on `SameSite=Strict` for now; full CSRF lives in the Leptos rewrite).

## Test plan

- [ ] Manual: visit `/download.php?file=http://169.254.169.254/latest/meta-data/` — must return 400 (HTTPS-only).
- [ ] Manual: visit `/download.php?file=https://attacker.example/x` — must return 403 (host not allow-listed).
- [ ] Manual: visit `/phpinfo.php` — must return 404.
- [ ] Manual: log in with remember-me, inspect cookies — must NOT see `userPassword`; `authToken` must have `HttpOnly` flag.
- [ ] Manual: log in as ADMIN role, hit `/admin/index.php` — must succeed (was previously 403).

🤖 Generated with [Claude Code](https://claude.com/claude-code)